### PR TITLE
v1.1.0 - Host Project Vars are now separated from library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tree-of-Life
 
-_version: 1.0.1_
+_version: 1.1.0_
 
 **Tree-of-Life** is a _Python-written_ and _stand-alone_ **library** that installs the Python dependencies and configures the _executable files_ for Python-based and **user-oriented** projects, and keeps them updated.
 

--- a/install/commons.py
+++ b/install/commons.py
@@ -27,6 +27,7 @@ import shutil
 import ctypes
 
 from install import logger
+from install import host_project_vars
 from install import system
 from install import messages
 from install import executables
@@ -65,11 +66,11 @@ def check_available_disk_space(min_space=None):
     Parameters:
     
         - min_space (float): the minimum space allowed in GBs.
-            Defaults to system.min_space_allowed
+            Defaults to host_project_vars.min_space_allowed
     
     """
     
-    min_space = min_space or system.min_space_allowed
+    min_space = min_space or host_project_vars.min_space_allowed
     log.debug("<min_space>: {}".format(min_space))
     
     try:

--- a/install/condamanager.py
+++ b/install/condamanager.py
@@ -36,7 +36,6 @@ else:
 you should use versions 2 or 3.".format(python_version))
 
 from install import logger
-from install import host_project_vars
 from install import system
 from install import messages
 from install import commons

--- a/install/condamanager.py
+++ b/install/condamanager.py
@@ -35,8 +35,9 @@ else:
     sys.exit("* ABORTING * You are using a Python '{}', \
 you should use versions 2 or 3.".format(python_version))
 
-from install import system
 from install import logger
+from install import host_project_vars
+from install import system
 from install import messages
 from install import commons
 

--- a/install/executables.py
+++ b/install/executables.py
@@ -70,6 +70,7 @@ if sys.version_info[0] != 3:
     sys.exit(1)
 
 from install import logger
+from install import host_project_vars
 from install import messages
 from install import system
 from install import executables
@@ -127,7 +128,7 @@ for _path in list_of_paths:
         input(messages.terminate)
         sys.exit(1)
 
-update_log = install_dir.joinpath(system.update_log_name)
+update_log = install_dir.joinpath(host_project_vars.update_log_name)
 
 if update_log.exists():
     update_log.unlink()
@@ -144,6 +145,7 @@ upf = updater.Updater(install_dir)
 upf.run()
 
 # reloads the libs updated version
+importlib.reload(host_project_vars)
 importlib.reload(system)
 importlib.reload(executables)
 

--- a/install/host_project_vars.py
+++ b/install/host_project_vars.py
@@ -32,14 +32,14 @@ install_wiki = "https://github.com/joaomcteixeira/Tree-of-Life/wiki"
 mailist = "https://github.com/joaomcteixeira/Tree-of-Life/issues"
 
 # min GB required to install the host project
-# usually depends on the Miniconda ENV 
+# usually depends on the Miniconda ENV
 min_space_allowed = 3
 
 # name of the LOG files
 installation_log_name = "tree_of_life_install.log"
 update_log_name = "tree_of_life_update.log"
 
-# the Miniconda ENV file specific of the host project 
+# the Miniconda ENV file specific of the host project
 env_file = "template_env.yml"
 
 # Miniconda installation folder

--- a/install/host_project_vars.py
+++ b/install/host_project_vars.py
@@ -1,0 +1,57 @@
+"""
+Specific variables for the host project.
+
+Copyright © 2018-2019 Tree-of-Life
+
+Contributors to this file:
+- João M.C. Teixeira (https://github.com/joaomcteixeira)
+
+Tree-of-Life is free software: you can redistribute it and/or modify
+it under the terms of the LGPL - GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+LGPL - GNU Lesser General Public License for more details.
+
+You should have received a copy of the this license along
+with this library. If not, see <http://www.gnu.org/licenses/>.
+"""
+# CONFIGURE ACCORDING TO THE HOST PROJECT
+
+# host project name, this will be displayed in messages and throughout
+software_name = "TreeOfLife"
+
+# host project version
+software_version = (1, 0, 0)
+
+# provide a link and e-mail with further documentation on the install process
+install_wiki = "https://github.com/joaomcteixeira/Tree-of-Life/wiki"
+mailist = "https://github.com/joaomcteixeira/Tree-of-Life/issues"
+
+# min GB required to install the host project
+# usually depends on the Miniconda ENV 
+min_space_allowed = 3
+
+# name of the LOG files
+installation_log_name = "tree_of_life_install.log"
+update_log_name = "tree_of_life_update.log"
+
+# the Miniconda ENV file specific of the host project 
+env_file = "template_env.yml"
+
+# Miniconda installation folder
+miniconda_folder = "miniconda"
+
+# the path where the host project is hosted
+# serves updating purposes
+new_version_url = \
+    "https://github.com/joaomcteixeira/Tree-of-Life/archive/master.zip"
+    
+# temporary ZIP file for the new version during update
+new_version_zip = "master.zip"
+
+# folders to remove during the update
+folders_to_remove = ["install", ".github"]

--- a/install/messages.py
+++ b/install/messages.py
@@ -22,12 +22,15 @@ with this library. If not, see <http://www.gnu.org/licenses/>.
 import os
 import textwrap
 
+from install import host_project_vars
 from install import system
 from install import executables
 
 # provide a link and e-mail with further documentation on the install process
-install_wiki = "https://github.com/joaomcteixeira/Tree-of-Life/wiki"
-mailist = "https://github.com/joaomcteixeira/Tree-of-Life/issues"
+install_wiki = host_project_vars.install_wiki
+mailist = host_project_vars.mailist
+software_name = host_project_vars.software_name
+min_space_allowed = host_project_vars.min_space_allowed
 
 # configure textwrapper
 
@@ -173,7 +176,7 @@ envs_okay = "* OK * The Anaconda Environment installed SUCCESSFULLY"
 # MANUAL INSTALL
 
 _manual_install = (
-    "You chose to configure {} manually, ".format(system.software_name)
+    "You chose to configure {} manually, ".format(software_name)
     + "no Python libraries will be installed now.\n"
     "\n"
     "We assume that you are a proficient Python user and "
@@ -183,15 +186,15 @@ _manual_install = (
     "You can check the required Python libraries in the '.yml' env file "
     "inside the 'install' folder. Use this file to create your own "
     "Anaconda environment if you use Anaconda or as a guide to know "
-    "which are the Python dependencies for {}.\n".format(system.software_name)
+    "which are the Python dependencies for {}.\n".format(software_name)
     + "\n"
     "The installer will now generate TEMPLATE executable files. You may "
-    "WISH or NEED to MODIFY {}'s".format(system.software_name)
+    "WISH or NEED to MODIFY {}'s".format(software_name)
     + " executable files according to "
     "your system's and Python preferences.\n"
     "If you don't install the required Python libraries and don't correctly "
     "configure the executable files, "
-    "{} MIGHT NOT WORK.".format(system.software_name)
+    "{} MIGHT NOT WORK.".format(software_name)
     )
 
 manual_install = (
@@ -225,7 +228,7 @@ consider_reinstall = (
 _update_perfect = """
 {} update COMPLETED successfully
 Press ENTER to finish
-""".format(system.software_name)
+""".format(software_name)
 
 update_completed = (
     _formats_main_title("perfect")
@@ -255,7 +258,7 @@ additional_help = (
 not_enough_space = """
 * Not enought space available to install the required Miniconda packages.
 * At lest {} GB are necessary.
-""".format(system.min_space_allowed)
+""".format(min_space_allowed)
 
 unknown_python = """
 * ERROR * We detected a Python version that is not 2 nor 3.

--- a/install/system.py
+++ b/install/system.py
@@ -40,7 +40,7 @@ exec_file_extension = _executable_file_extensions[platform]
 latest_env_file = os.path.join(_file_path, host_project_vars.env_file)
 default_miniconda_folder = os.path.join(
     installation_folder,
-    host_project_varsminiconda_folder
+    host_project_vars.miniconda_folder
     )
 
 with open(latest_env_file, 'r') as f:

--- a/install/system.py
+++ b/install/system.py
@@ -22,15 +22,7 @@ with this library. If not, see <http://www.gnu.org/licenses/>.
 """
 import platform as pltfrm
 import os
-
-# configure accordingly to the host project
-software_name = "TreeOfLife"
-software_version = (1, 0, 0)  # v1.0.0
-min_space_allowed = 3  # min GB required to install your software
-installation_log_name = "tree_of_life_install.log"
-update_log_name = "tree_of_life_update.log"
-_lastest_env_file = "template_env.yml"
-_miniconda_folder = "miniconda"
+from install import host_project_vars
 
 # about the default installation folder
 _file_path = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
@@ -45,8 +37,11 @@ bits = "x86_64" if (pltfrm.machine().endswith('64')) else "x86"
 exec_file_extension = _executable_file_extensions[platform]
 
 # about conda env
-latest_env_file = os.path.join(_file_path, _lastest_env_file)
-default_miniconda_folder = os.path.join(installation_folder, _miniconda_folder)
+latest_env_file = os.path.join(_file_path, host_project_vars.env_file)
+default_miniconda_folder = os.path.join(
+    installation_folder,
+    host_project_varsminiconda_folder
+    )
 
 with open(latest_env_file, 'r') as f:
     for line in f:

--- a/install/updater.py
+++ b/install/updater.py
@@ -41,13 +41,13 @@ import zipfile
 import time
 
 from install import logger
+from install import host_project_vars
 from install import commons
 from install import messages
 
-_new_version_url = \
-    "https://github.com/joaomcteixeira/Tree-of-Life/archive/master.zip"
-_new_version_zip = "master.zip"
-_folders_to_remove = ["install", ".github"]
+_new_version_url = host_project_vars.new_version_url
+_new_version_zip = host_project_vars.new_version_zip
+_folders_to_remove = host_project_vars.folders_to_remove
 
 
 class Updater():

--- a/tree_of_life.py
+++ b/tree_of_life.py
@@ -28,6 +28,7 @@ libs_folder = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 # appends 'install' folder to allow lib import
 sys.path.append(os.path.join(libs_folder, "install"))
 
+from install import host_project_vars
 from install import system
 from install import messages
 # logging is required before importing the other package libs
@@ -36,7 +37,7 @@ from install import logger
 # STARTS LOGGING
 logfile_name = os.path.join(
     system.installation_folder,
-    system.installation_log_name
+    host_project_vars.installation_log_name
     )
 
 if os.path.exists(logfile_name):
@@ -57,7 +58,7 @@ elif python_version == 3:
 else:
     log.info(messages.unknown_python)
     log.info("* You are running Python version: {}".format(python_version))
-    _name = system.software_name
+    _name = host_project_vars.software_name
     log.info("* {} requires Python 2.7 or 3.x to execute".format(_name))
     log.info(messages.additional_help)
     log.info(messages.abort)
@@ -76,7 +77,7 @@ from install import commons
 from install import condamanager
 
 # STARTS INSTALLATION
-log.debug("{} installation initiated".format(system.software_name))
+log.debug("{} installation initiated".format(host_project_vars.software_name))
 log.debug("<installation_folder>: {}".format(system.installation_folder))
 log.info(messages.banner)
 log.info(messages.start_install)


### PR DESCRIPTION
Addresses issue #2 - separates host project configurable variables from library code.

- proposed version: 1.1.0
- Designed to facilitate implementation of Tree-of-Life in host projects
- variables that configure host project details are now stored only in `host_project_vars.py`. 
